### PR TITLE
Translate to cpp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode
 test.wasm
+a.out

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vscode
+test.wasm

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# Approach 1
+To test `t4.cpp`:
+
+    g++ t4.cpp && ./a.out && node test.js
+
+---
+
+# Approach 2
 Run:
 
     conda create -n wasm python

--- a/t4.cpp
+++ b/t4.cpp
@@ -1,0 +1,238 @@
+#include <vector>
+#include <fstream>
+#include <cassert>
+#include <cstring>
+
+std::vector<uint8_t> encode_signed_leb128(int32_t n) {
+    std::vector<uint8_t> out;
+    auto more = true;
+    do {
+        uint8_t byte = n & 0x7f;
+        n >>= 7;
+        more = !((((n == 0) && ((byte & 0x40) == 0)) ||
+                  ((n == -1) && ((byte & 0x40) != 0))));
+        if (more) {
+            byte |= 0x80;
+        }
+        out.emplace_back(byte);
+    } while (more);
+    return out;
+}
+
+std::vector<uint8_t> encode_unsigned_leb128(uint32_t n) {
+    std::vector<uint8_t> out;
+    do {
+        uint8_t byte = n & 0x7f;
+        n >>= 7;
+        if (n != 0) {
+            byte |= 0x80;
+        }
+        out.emplace_back(byte);
+    } while (n != 0);
+    return out;
+}
+
+class WASMAssembler {
+   public:
+    uint8_t i32 = 0x7F;
+    uint8_t i64 = 0x7E;
+    uint8_t f32 = 0x7D;
+    uint8_t f64 = 0x7C;
+
+    std::vector<uint8_t> code;
+
+    WASMAssembler() { code.clear(); }
+
+    // function to save to binary file with the given filename
+    void save_bin(const char* filename) {
+        FILE* fp = fopen(filename, "wb");
+        fwrite(code.data(), sizeof(uint8_t), code.size(), fp);
+        fclose(fp);
+    }
+
+    // function to emit header of Wasm Binary Format
+    void emit_header() {
+        code.push_back(0x00);
+        code.push_back(0x61);
+        code.push_back(0x73);
+        code.push_back(0x6D);
+        code.push_back(0x01);
+        code.push_back(0x00);
+        code.push_back(0x00);
+        code.push_back(0x00);
+    }
+
+    // function to emit unsigned 32 bit integer
+    void emit_u32(uint32_t x) {
+        std::vector<uint8_t> leb128 = encode_unsigned_leb128(x);
+        code.insert(code.end(), leb128.begin(), leb128.end());
+    }
+
+    // function to emit signed 32 bit integer
+    void emit_i32(int32_t x) {
+        std::vector<uint8_t> leb128 = encode_signed_leb128(x);
+        code.insert(code.end(), leb128.begin(), leb128.end());
+    }
+
+    // function to append a given bytecode to the end of the code
+    void emit_b8(uint8_t x) { code.push_back(x); }
+
+    void emit_u32_b32_idx(uint8_t idx, uint8_t i){
+        /*
+        Encodes the integer `i` using LEB128 and adds trailing zeros to always
+        occupy 4 bytes. Stores the int `i` at the index `idx` in `code`.
+        */
+        std::vector<uint8_t> num = encode_unsigned_leb128(i);
+        std::vector<uint8_t> num_4b = {0x80, 0x80, 0x80, 0x00};
+        assert(num.size() <= 4);
+        for (int i = 0; i < num.size(); i++) {
+            num_4b[i] |= num[i];
+        }
+        for(int i = 0; i < 4; i++){
+            code[idx+i] = num_4b[i];
+        }
+    }
+
+    // function to fixup length at the given length index
+    void fixup_len(uint32_t len_idx) {
+        uint32_t section_len = code.size() - len_idx - 4u;
+        emit_u32_b32_idx(len_idx, section_len);
+    }
+
+    // function to emit length placeholder
+    uint32_t emit_len_placeholder() {
+        uint32_t len_idx = code.size();
+        code.push_back(0x00);
+        code.push_back(0x00);
+        code.push_back(0x00);
+        code.push_back(0x00);
+        return len_idx;
+    }
+
+    // function to emit a i32.const instruction
+    void emit_i32_const(int32_t x) {
+        code.push_back(0x41);
+        emit_i32(x);
+    }
+
+    // function to emit end of wasm expression
+    void emit_end() { code.push_back(0x0B); }
+
+    // function to emit get local variable at given index
+    void emit_get_local(uint32_t idx) {
+        code.push_back(0x20);
+        emit_u32(idx);
+    }
+
+    // function to emit i32.add instruction
+    void emit_i32_add() { code.push_back(0x6A); }
+
+    // function to emit call instruction
+    void emit_call(uint32_t idx) {
+        code.push_back(0x10);
+        emit_u32(idx);
+    }
+};
+
+// Functions to emit WASM Sections
+
+void emit_fn_type(WASMAssembler& wasm, std::vector<uint8_t> param_types,
+                  std::vector<uint8_t> return_types) {
+    wasm.emit_b8(0x60);
+    wasm.emit_u32(param_types.size());
+    wasm.code.insert(wasm.code.end(), param_types.begin(), param_types.end());
+    wasm.emit_u32(return_types.size());
+    wasm.code.insert(wasm.code.end(), return_types.begin(), return_types.end());
+}
+
+void emit_type_section(WASMAssembler& wasm) {
+    wasm.emit_u32(1);
+    uint32_t len_idx = wasm.emit_len_placeholder();
+
+    wasm.emit_u32(2);  // number of functions
+    emit_fn_type(wasm, {}, {wasm.i32});
+    emit_fn_type(wasm, {wasm.i32, wasm.i32}, {wasm.i32});
+    wasm.fixup_len(len_idx);
+}
+
+void emit_function_section(WASMAssembler& wasm) {
+    wasm.emit_u32(3);
+    uint32_t len_idx = wasm.emit_len_placeholder();
+
+    wasm.emit_u32(2);  // number of functions
+
+    // function indices
+    wasm.emit_u32(0);
+    wasm.emit_u32(1);
+    wasm.fixup_len(len_idx);
+}
+
+void emit_export_fn(WASMAssembler& wasm, const std::string& name,
+                    uint32_t idx) {
+    std::vector<uint8_t> name_bytes(name.size());
+    std::memcpy(name_bytes.data(), name.data(), name.size());
+    wasm.emit_u32(name_bytes.size());
+    wasm.code.insert(wasm.code.end(), name_bytes.begin(), name_bytes.end());
+    wasm.emit_b8(0x00);
+    wasm.emit_u32(idx);
+}
+
+void emit_export_section(WASMAssembler& wasm) {
+    wasm.emit_u32(7);
+    uint32_t len_idx = wasm.emit_len_placeholder();
+
+    wasm.emit_u32(2);  // number of functions
+    emit_export_fn(wasm, "get_const_val", 0);
+    emit_export_fn(wasm, "add_two_nums", 1);
+    wasm.fixup_len(len_idx);
+}
+
+void emit_function_1(WASMAssembler& wasm) {
+    uint32_t len_idx = wasm.emit_len_placeholder();
+
+    // Local vars
+    wasm.emit_u32(0);
+
+    // Instructions
+    wasm.emit_i32_const(-10);
+    wasm.emit_end();
+
+    wasm.fixup_len(len_idx);
+}
+
+void emit_function_2(WASMAssembler& wasm) {
+    uint32_t len_idx = wasm.emit_len_placeholder();
+
+    // Local vars
+    wasm.emit_u32(0);
+
+    // Instructions
+    wasm.emit_get_local(0);
+    wasm.emit_get_local(1);
+    wasm.emit_i32_add();
+    wasm.emit_call(0);
+    wasm.emit_i32_add();
+    wasm.emit_end();
+
+    wasm.fixup_len(len_idx);
+}
+
+void emit_code_section(WASMAssembler& wasm) {
+    wasm.emit_u32(10);
+    uint32_t len_idx = wasm.emit_len_placeholder();
+
+    wasm.emit_u32(2);  // number of functions
+    emit_function_1(wasm);
+    emit_function_2(wasm);
+    wasm.fixup_len(len_idx);
+}
+
+int main() {
+    WASMAssembler wasm;
+    wasm.emit_header();
+    emit_type_section(wasm);
+    emit_function_section(wasm);
+    emit_export_section(wasm);
+    emit_code_section(wasm);
+    wasm.save_bin("test.wasm");
+}

--- a/test.js
+++ b/test.js
@@ -1,0 +1,12 @@
+const fs = require('fs');
+const wasmBuffer = fs.readFileSync('./test.wasm');
+
+WebAssembly.instantiate(wasmBuffer).then(wasmModule => {
+    // Exported function live under instance.exports
+    const get_const_val = wasmModule.instance.exports.get_const_val;
+    const add_two_nums = wasmModule.instance.exports.add_two_nums;
+
+    console.log(get_const_val());
+    console.log(add_two_nums(5, 4));
+    console.log("Success!")
+});

--- a/wasm_binary_experimentation.ipynb
+++ b/wasm_binary_experimentation.ipynb
@@ -1,0 +1,838 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "wasm_binary_experimentation.ipynb",
+      "provenance": [],
+      "collapsed_sections": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# WASM Binary Experimentation"
+      ],
+      "metadata": {
+        "id": "avf_4nXsyjV6"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "In this notebook, let us write a `python` script which writes `wasm` binary. (Yup, you read it right, writing a script that writes another script, 😎)\n",
+        "\n",
+        "For example, let us aim to write the following `WAT` in `wasm` binary using our `python` script.\n",
+        "\n",
+        "```\n",
+        "(module\n",
+        "  (func (export \"get_const_val\") (result i32)\n",
+        "    i32.const -10)\n",
+        "  (func (export \"add_two_nums\") (param i32 i32) (result i32)\n",
+        "    local.get 0\n",
+        "    local.get 1\n",
+        "    i32.add)\n",
+        "  (func (export \"call_functions\") (result i32)\n",
+        "    call 0\n",
+        "    call 0\n",
+        "    call 1)\n",
+        ")\n",
+        "```\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "qrSmbPPS3Lxq"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "- The function `get_const_val` returns a constant value of `-10`.\n",
+        "- The function `add_two_nums` adds the given numbers and returns the result of addition.\n",
+        "- The function `call_functions` calls `get_const_val` twice and then calls `add_two_nums`. Please note here that we used the indexes of the `get_const_val` and `add_two_nums` when calling them."
+      ],
+      "metadata": {
+        "id": "t8SSS-a_4b3a"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "In python, the implementation of these functions would be as follows:"
+      ],
+      "metadata": {
+        "id": "VBxr1iPE5Q7V"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def get_const_val():\n",
+        "  return -10\n",
+        "\n",
+        "def add_two_nums(a, b): # in the WAT format, we did not give names, instead we used indexes to refer to the parameters\n",
+        "  return a + b\n",
+        "\n",
+        "def call_functions():\n",
+        "  return add_two_nums(get_const_val(), get_const_val())"
+      ],
+      "metadata": {
+        "id": "NLNHiSMr47B_"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Our `python` script starts from the following sections.\n",
+        "\n",
+        "**Let's dive in!!!**"
+      ],
+      "metadata": {
+        "id": "TjgEQ5SW5mFr"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Importing required modules"
+      ],
+      "metadata": {
+        "id": "lraBJEEnymkE"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "`wasm` expects integers to be in `leb128` (Little Endian Base 128) format. So, we use the following library/module to encode the `integers` (`signed` as well as `unsigned`).\n",
+        "Also, from my experience, `index` of variables/functions are being considered to be `integers` and therefore need to be encoded."
+      ],
+      "metadata": {
+        "id": "NIj1X58RzXU0"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!pip install leb128\n",
+        "import leb128"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "XuN668RXv7Tb",
+        "outputId": "0478667c-7dc6-4329-e506-b561cdcc48ec"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Requirement already satisfied: leb128 in /usr/local/lib/python3.7/dist-packages (1.0.4)\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "To test the generated `test.wasm` we need to import the `wasm` exported functions in `JavaScript`/`node.js`. Since, it seems that `Google Colab` supports only `client` side `JavaScript` and does not support `node.js`, here, we can currently (temporarily) use `pywasm` (which provides the `WebAssembly` runtime for `python`) to test the exported function."
+      ],
+      "metadata": {
+        "id": "36YtGSqMzpPV"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!pip install pywasm\n",
+        "import pywasm"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "j6xkYI3FvtwN",
+        "outputId": "40e3e9c6-e57e-480f-86e3-6ae23cb10426"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Requirement already satisfied: pywasm in /usr/local/lib/python3.7/dist-packages (1.0.7)\n",
+            "Requirement already satisfied: numpy in /usr/local/lib/python3.7/dist-packages (from pywasm) (1.21.6)\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Generating the `test.wasm` binary"
+      ],
+      "metadata": {
+        "id": "NjoVcoU80Ojl"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "A `wasm` binary starts with `module` and `version`\n",
+        "\n",
+        "here:\n",
+        "- `module` = \"\\0asm\"\n",
+        "- `version` = 1"
+      ],
+      "metadata": {
+        "id": "lzYD8dGP0UNW"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "module = bytearray([0x00, 0x61, 0x73, 0x6d])\n",
+        "version = bytearray([0x01, 0x00, 0x00, 0x00])"
+      ],
+      "metadata": {
+        "id": "xMIg1RoO0aul"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "`wasm` binary consists of the following sections. These sections come after the `mdoule` and `version`.\n",
+        "\n",
+        "| Id  | Section            |\n",
+        "|:----|:-------------------|\n",
+        "| 0   | custom section     |\n",
+        "| 1   | type section       |\n",
+        "| 2   | import section     |\n",
+        "| 3   | function section   |\n",
+        "| 4   | table section      |\n",
+        "| 5   | memory section     |\n",
+        "| 6   | global section     |\n",
+        "| 7   | export section     |\n",
+        "| 8   | start section      |\n",
+        "| 9   | element section    |\n",
+        "| 10  | code section       |\n",
+        "| 11  | data section       |\n",
+        "| 12  | data count section |\n",
+        "\n",
+        "Each section consists of\n",
+        "\n",
+        "- a one-byte section id,\n",
+        "- the  size of the contents, in bytes,\n",
+        "- the actual contents, whose structure is depended on the section id.\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "JoeSW9dv073B"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "These sections can either be omitted or can be present atmost once. Also, these sections need to be present in the specific order.\n",
+        "\n",
+        "Let us define the sections we need in the following cells."
+      ],
+      "metadata": {
+        "id": "F9rdAe251mqx"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Type Section"
+      ],
+      "metadata": {
+        "id": "PjggIAPu6WPw"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "From my understanding, this section is used to declare `function type` that is `function signature` (I assume this to be similar to `function declaration` or `function prototyping` in `C`/`C++`)"
+      ],
+      "metadata": {
+        "id": "WUKGxm0Z6Y1b"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Let's define the functions types for our three functions (`get_const_val`, `add_two_nums`, `call_functions`) one by one"
+      ],
+      "metadata": {
+        "id": "VxjLv3Kj7AeD"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "param_types_get_const_val = bytearray([]) # its parameter list is empty\n",
+        "param_types_get_const_val = leb128.u.encode(len(param_types_get_const_val)) + param_types_get_const_val # prepend length (in encoded form) of the list to itself\n",
+        "\n",
+        "return_types_get_const_val = bytearray([0x7f]) # its return list is just integer\n",
+        "return_types_get_const_val = leb128.u.encode(len(return_types_get_const_val)) + return_types_get_const_val # prepend length (in encoded form) of the list to itself\n",
+        "\n",
+        "func_type_get_const_val = bytearray([0x60]) + param_types_get_const_val + return_types_get_const_val"
+      ],
+      "metadata": {
+        "id": "ya_Gi3Rt7CgU"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "param_types_add_two_nums = bytearray([0x7f, 0x7f]) # its parameter list is two integers\n",
+        "param_types_add_two_nums = leb128.u.encode(len(param_types_add_two_nums)) + param_types_add_two_nums # prepend length (in encoded form) of the list to itself\n",
+        "\n",
+        "return_types_add_two_nums = bytearray([0x7f]) # its return list is just integer\n",
+        "return_types_add_two_nums = leb128.u.encode(len(return_types_add_two_nums)) + return_types_add_two_nums # prepend length (in encoded form) of the list to itself\n",
+        "\n",
+        "func_type_add_two_nums = bytearray([0x60]) + param_types_add_two_nums + return_types_add_two_nums"
+      ],
+      "metadata": {
+        "id": "yVcTW8Oi8W2k"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "param_types_call_functions = bytearray([]) # its parameter list is empty\n",
+        "param_types_call_functions = leb128.u.encode(len(param_types_call_functions)) + param_types_call_functions # prepend length (in encoded form) of the list to itself\n",
+        "\n",
+        "return_types_call_functions = bytearray([0x7f]) # its return list is just integer\n",
+        "return_types_call_functions = leb128.u.encode(len(return_types_call_functions)) + return_types_call_functions # prepend length (in encoded form) of the list to itself\n",
+        "\n",
+        "func_type_call_functions = bytearray([0x60]) + param_types_call_functions + return_types_call_functions"
+      ],
+      "metadata": {
+        "id": "R_gw0reX8uvF"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Let us now define our `type` section"
+      ],
+      "metadata": {
+        "id": "hYc_EcvK9CMc"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "func_types = [func_type_get_const_val, func_type_add_two_nums, func_type_call_functions] # take care to add these functions in proper order, as we will use indexes to refer them\n",
+        "\n",
+        "type_section_id = leb128.u.encode(1) # id of type section is 1\n",
+        "\n",
+        "type_section_content = leb128.u.encode(\n",
+        "    len(func_types))  # first add length (in encoded form) and then\n",
+        "for func_type in func_types: # add the contents of func_types\n",
+        "    type_section_content.extend(func_type)"
+      ],
+      "metadata": {
+        "id": "rtWCWmIAvxzJ"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "type_section = type_section_id + leb128.u.encode(len(type_section_content)) + type_section_content"
+      ],
+      "metadata": {
+        "id": "T29MpQf5-STa"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Function Section"
+      ],
+      "metadata": {
+        "id": "ulHfDprk9hAq"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "So, from the section name, it seems we will be defining our `functions` in this section. From my understanding, we need to break our function definition into parts, the function prototype and the function body. (Yup, I know we already declared our function prototypes in the `type` section)"
+      ],
+      "metadata": {
+        "id": "BJ43Kj269oBf"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Here, instead of redeclaring our `function types` (or `function prototypes` as I understand them), we will reference the already defined `function type`. That is we will just specify an index to the `function type` that we wish to have for our `function`."
+      ],
+      "metadata": {
+        "id": "EEWvUbk-_BBj"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "The next question that comes here is that\n",
+        "- ok, I referenced the `function type` (lets say) at index `0`, where do I write its `function body`?\n",
+        "\n",
+        "`ans:` As per the [WebAssembly Docs](https://webassembly.github.io/spec/core/binary/modules.html#binary-codesec), it happens that, `function bodies` (`local variables` + `statements` are to be mentioned in the `code section`). "
+      ],
+      "metadata": {
+        "id": "_dSrxSNq_WLb"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "So, let's go ahead and reference the three declared `function types`"
+      ],
+      "metadata": {
+        "id": "3KUxHaQGAMkX"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "type_ids = bytearray([0, 1, 2])\n",
+        "\n",
+        "func_section_id = leb128.u.encode(3)  # id of function section is 3\n",
+        "func_section_content = leb128.u.encode(\n",
+        "    len(type_ids)) # first add length (in encoded form) and then\n",
+        "func_section_content += type_ids # add the contents of type_ids"
+      ],
+      "metadata": {
+        "id": "U8dU9Q3x9u0T"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "func_section = func_section_id + leb128.u.encode(len(func_section_content)) + func_section_content"
+      ],
+      "metadata": {
+        "id": "p-TrJbaqAvfN"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Code Section"
+      ],
+      "metadata": {
+        "id": "LvedL0YnA1uE"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "We define our  `function bodies` (`local variables` + `statements`) for our three functions (`get_const_val`, `add_two_nums`, `call_functions`) in this section."
+      ],
+      "metadata": {
+        "id": "eFYRkoKDA3XR"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "local_vars_get_const_val = bytearray([]) # it does not contain any local variables\n",
+        "local_vars_get_const_val = leb128.u.encode(len(local_vars_get_const_val)) + local_vars_get_const_val\n",
+        "\n",
+        "instructions_get_const_val_1 = bytearray([0x41]) + leb128.i.encode(-10) # it contains just one instruction\n",
+        "\n",
+        "expr_get_const_val = instructions_get_const_val_1 + bytearray([0x0b]) # expression contains all instructions and it ends with byte 0x0b\n",
+        "\n",
+        "func_get_const_val = local_vars_get_const_val + expr_get_const_val\n",
+        "\n",
+        "code_get_const_val = leb128.u.encode(len(func_get_const_val)) + func_get_const_val"
+      ],
+      "metadata": {
+        "id": "ELhRtgRpBC0a"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "local_vars_add_two_nums = bytearray([]) # it does not contain any local variables\n",
+        "local_vars_add_two_nums = leb128.u.encode(len(local_vars_add_two_nums)) + local_vars_add_two_nums\n",
+        "\n",
+        "instructions_add_two_nums_1 = bytearray([0x20]) + leb128.u.encode(0) # get parameter 0\n",
+        "instructions_add_two_nums_2 = bytearray([0x20]) + leb128.u.encode(1) # get parameter 1\n",
+        "instructions_add_two_nums_3 = bytearray([0x6a]) # add the two operands on the stack\n",
+        "\n",
+        "expr_add_two_nums = instructions_add_two_nums_1 + instructions_add_two_nums_2 + instructions_add_two_nums_3 + bytearray([0x0b]) # expression contains all instructions and it ends with byte 0x0b\n",
+        "\n",
+        "func_add_two_nums = local_vars_add_two_nums + expr_add_two_nums\n",
+        "\n",
+        "code_add_two_nums = leb128.u.encode(len(func_add_two_nums)) + func_add_two_nums"
+      ],
+      "metadata": {
+        "id": "-_qmXmoKDOsF"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "local_vars_call_functions = bytearray([]) # it does not contain any local variables\n",
+        "local_vars_call_functions = leb128.u.encode(len(local_vars_call_functions)) + local_vars_call_functions\n",
+        "\n",
+        "instructions_call_functions_1 = bytearray([0x10]) + leb128.u.encode(0) # call function get_const_val\n",
+        "instructions_call_functions_2 = bytearray([0x10]) + leb128.u.encode(0) # call function get_const_val\n",
+        "instructions_call_functions_3 = bytearray([0x10]) + leb128.u.encode(1) # call function call_functions and pass the two values on the stack, that is (-10, -10)\n",
+        "\n",
+        "expr_call_functions = instructions_call_functions_1 + instructions_call_functions_2 + instructions_call_functions_3 + bytearray([0x0b]) # expression contains all instructions and it ends with byte 0x0b\n",
+        "\n",
+        "func_call_functions = local_vars_call_functions + expr_call_functions\n",
+        "\n",
+        "code_call_functions = leb128.u.encode(len(func_call_functions)) + func_call_functions"
+      ],
+      "metadata": {
+        "id": "iPghNpo1BExm"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "codes = [code_get_const_val, code_add_two_nums, code_call_functions]\n",
+        "\n",
+        "code_section_id = leb128.u.encode(10) # id of code section is 10\n",
+        "code_section_content = leb128.u.encode(len(codes)) # first add length (in encoded form) and then\n",
+        "for code in codes: # add the contents of codes\n",
+        "    code_section_content.extend(code)"
+      ],
+      "metadata": {
+        "id": "GESYopoJ9wGA"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "code_section = code_section_id + leb128.u.encode(len(code_section_content)) + code_section_content"
+      ],
+      "metadata": {
+        "id": "nt1pONIXBGts"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Please, note here that, the number of `types referenced` and the number of `function bodies` defined must match."
+      ],
+      "metadata": {
+        "id": "z8HmzrsGINJN"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Export Section"
+      ],
+      "metadata": {
+        "id": "GtNcBx5AEimW"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Now, we need to export our three functions (`get_const_val`, `add_two_nums`, `call_functions`), so that we can use them in `JavaScript`"
+      ],
+      "metadata": {
+        "id": "4L8xgFKuEk_f"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "name_get_const_val = \"get_const_val\".encode(encoding=\"utf-8\")\n",
+        "name_get_const_val = leb128.u.encode(len(name_get_const_val)) + bytearray(name_get_const_val) # add length (in encoded form) followed by the encoded name string\n",
+        "\n",
+        "export_desc_get_const_val = bytearray([0x00]) + leb128.u.encode(0)  # encoding function index\n",
+        "\n",
+        "export_get_const_val = name_get_const_val + export_desc_get_const_val"
+      ],
+      "metadata": {
+        "id": "Tb0s4WZ19yeG"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "name_add_two_nums = \"add_two_nums\".encode(encoding=\"utf-8\")\n",
+        "name_add_two_nums = leb128.u.encode(len(name_add_two_nums)) + bytearray(name_add_two_nums) # add length (in encoded form) followed by the encoded name string\n",
+        "\n",
+        "export_desc_add_two_nums = bytearray([0x00]) + leb128.u.encode(1)  # encoding function index\n",
+        "\n",
+        "export_add_two_nums = name_add_two_nums + export_desc_add_two_nums"
+      ],
+      "metadata": {
+        "id": "KZnLorwwE_cZ"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "name_call_functions = \"call_functions\".encode(encoding=\"utf-8\")\n",
+        "name_call_functions = leb128.u.encode(len(name_call_functions)) + bytearray(name_call_functions) # add length (in encoded form) followed by the encoded name string\n",
+        "\n",
+        "export_desc_call_functions = bytearray([0x00]) + leb128.u.encode(2)  # encoding function index\n",
+        "\n",
+        "export_call_functions = name_call_functions + export_desc_call_functions"
+      ],
+      "metadata": {
+        "id": "smPcDey7E_8A"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "exports = [export_get_const_val, export_add_two_nums, export_call_functions]\n",
+        "\n",
+        "export_section_id = leb128.u.encode(7) # id of export section is 10\n",
+        "export_section_content = leb128.u.encode(\n",
+        "    len(exports)) # first add length (in encoded form) and then\n",
+        "for export in exports: # add the contents of exports\n",
+        "    export_section_content.extend(export)"
+      ],
+      "metadata": {
+        "id": "vvmqQOMcFDX7"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "export_section = export_section_id + leb128.u.encode(len(export_section_content)) + export_section_content"
+      ],
+      "metadata": {
+        "id": "MLUTFo6_FFH_"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Creating the final `test.wasm`"
+      ],
+      "metadata": {
+        "id": "2C6-4tBgCGeB"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "We combine all the above sections in the increasing order of section Ids. Incorrect order leads to inconsitent wasm module."
+      ],
+      "metadata": {
+        "id": "RL18v1S2FO9c"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "all_code = module + version + type_section + func_section + export_section + code_section"
+      ],
+      "metadata": {
+        "id": "4IwQzmur90SQ"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Now, we write our `all_code` to `binary file`"
+      ],
+      "metadata": {
+        "id": "Gdh0VL8hFZ6b"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "with open(\"test.wasm\", \"wb\") as wasm_file:\n",
+        "    wasm_file.write(bytes(all_code))"
+      ],
+      "metadata": {
+        "id": "3dd-oLaoFefm"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Testing Time!"
+      ],
+      "metadata": {
+        "id": "lMFvV6KjCK1X"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Let use first test our functions defined in `python`"
+      ],
+      "metadata": {
+        "id": "pQ0kfCV2IsoQ"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "print(get_const_val())\n",
+        "print(add_two_nums(5, 4))\n",
+        "print(call_functions())"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "KD2W_yWtIwn6",
+        "outputId": "5faf9a10-ce32-4876-ce70-3e9a4a25023a"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "-10\n",
+            "9\n",
+            "-20\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Now, to test our `wasm` functions, we need to import them in `JavaScript` and the call them (the code for the same in given in `Appendix` at the end). Since, it seems that Google Colab supports only client side JavaScript and does not support node.js, here, we can currently (temporarily) use pywasm (which provides the WebAssembly runtime for python) to test the exported function."
+      ],
+      "metadata": {
+        "id": "9_L7-VsMGpTb"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "runtime = pywasm.load('./test.wasm')"
+      ],
+      "metadata": {
+        "id": "h7QZjioWwDdZ"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "print(runtime.exec('get_const_val', []))\n",
+        "print(runtime.exec('add_two_nums', [5, 4]))\n",
+        "print(runtime.exec('call_functions', []))"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "HBdfXbnzInC4",
+        "outputId": "27b599d6-6f89-4d02-c93b-42dc857fcc1d"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "-10\n",
+            "9\n",
+            "-20\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Appendix"
+      ],
+      "metadata": {
+        "id": "CCQ_EglUJPVf"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "%%javascript\n",
+        "const fs = require('fs');\n",
+        "\n",
+        "const wasmBuffer = fs.readFileSync('./test.wasm');\n",
+        "\n",
+        "WebAssembly.instantiate(wasmBuffer).then(wasmModule => {\n",
+        "    // Exported function live under instance.exports\n",
+        "    const get_const_val = wasmModule.instance.exports.get_const_val;\n",
+        "    const add_two_nums = wasmModule.instance.exports.add_two_nums;\n",
+        "    const call_functions = wasmModule.instance.exports.call_functions;\n",
+        "    \n",
+        "    console.log(get_const_val());\n",
+        "    console.log(add_two_nums(5, 4));\n",
+        "    console.log(call_functions())\n",
+        "});"
+      ],
+      "metadata": {
+        "id": "1bDOLYsgJUpx"
+      },
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}


### PR DESCRIPTION
- the variable `wasm` represents the variable `a`
- function definitions for `leb128` signed as well as unsigned have been copied from [wasmblr](https://github.com/bwasti/wasmblr). It is of license MIT and can be seen [here](https://github.com/bwasti/wasmblr/blob/main/LICENSE).
    - signed from [here](https://github.com/bwasti/wasmblr/blob/b26dcd58f76f4458c3873eeaf52b4b4b0e83c7e3/wasmblr.h#L278)
    - unsigned from [here](https://github.com/bwasti/wasmblr/blob/b26dcd58f76f4458c3873eeaf52b4b4b0e83c7e3/wasmblr.h#L294)
- currently it temporarily uses `std::vector` instead of the custom `Vec`
- The `cpp` code works  :heavy_check_mark:
- Instructions to run and test the `cpp` code are added to `README.md`
- The WASM Binary tutorial notebook has also been added. If needed anyone can open this notebook using [Binder](https://mybinder.org/) and play/practice with the code.
