### PR TITLE
Bypass instructions

### DIFF
--- a/wasm_instructions_visitor.py
+++ b/wasm_instructions_visitor.py
@@ -146,8 +146,8 @@ param_type = {
 def parse_param_info(param_info):
     type_info, name, val = param_info.split(":")
     type = param_type[type_info]
-    read_fun = param_read_function[type]
-    return {"type": type, "read_func": read_fun, "name": name, "val": val}
+    read_func = param_read_function[type]
+    return {"type": type, "read_func": read_func, "name": name, "val": val}
 
 def parse_instructions(instructions):
     instructions_info = []

--- a/wasm_to_wat.cpp
+++ b/wasm_to_wat.cpp
@@ -84,6 +84,7 @@ void decode_code_section(uint32_t offset) {
 
     for (uint32_t i = 0; i < no_of_codes; i++) {
         codes[i].size = read_unsigned_num(offset);
+        uint32_t code_start_offset = offset;
         uint32_t no_of_locals = read_unsigned_num(offset);
         DEBUG("no_of_locals: " + std::to_string(no_of_locals));
         codes[i].locals.resize(no_of_locals);
@@ -99,10 +100,8 @@ void decode_code_section(uint32_t offset) {
 
         codes[i].insts_start_index = offset;
 
-        uint8_t cur_byte = wasm_bytes[offset++];
-        while (cur_byte != 0x0B) {  // omit the instructions
-            cur_byte = wasm_bytes[offset++];
-        }
+        // skip offset to directly the end of instructions
+        offset = code_start_offset + codes[i].size;
     }
 }
 


### PR DESCRIPTION
There was an improvement suggested by @certik to skip going over the instructions when decoding the `code section`. I am sorry, I missed to include the change in the previous PR #4 . This PR adds that change.

There is also a minor variable name change in the first commit ([Rename variable read_fun to read_func](https://github.com/certik/test_wasm/commit/24a702466c2e9ed0ed6bbd493efaf74e8df718d4)) in this PR.